### PR TITLE
Package with ncc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,2 @@
-fixtures/error
 build
 dist
-example/**/double.js
-example/**/single.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 fixtures/error
 build
+dist
 example/**/double.js
 example/**/single.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
+dist
 tsconfig.tsbuildinfo
 tsconfig.prod.tsbuildinfo
 .DS_Store

--- a/bin/relabel
+++ b/bin/relabel
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../build/cli.js');
+require('../dist/index.js');

--- a/package.json
+++ b/package.json
@@ -7,27 +7,19 @@
     "relabel": "bin/relabel"
   },
   "files": [
-    "build",
+    "dist",
     "bin"
   ],
   "license": "MIT",
   "scripts": {
     "prepare": "husky install",
-    "watch": "yarn tsc --watch --incremental",
-    "build": "yarn tsc",
+    "watch": "newsh --split 'yarn tsc --watch' && yarn pkg --watch",
+    "pkg": "ncc build build/cli.js -o dist",
+    "build": "yarn tsc && yarn pkg",
     "lint": "eslint .",
     "test": "jest",
     "clean-build": "rm -rf build tsconfig.tsbuildinfo",
     "createVersion": "np"
-  },
-  "dependencies": {
-    "arg": "^5.0.0",
-    "chalk": "^4.1.0",
-    "fs-extra": "^9.0.1",
-    "globby": "^11.0.2",
-    "ink": "^3.0.8",
-    "react": "^17.0.1",
-    "update-notifier": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.13.10",
@@ -40,19 +32,28 @@
     "@types/update-notifier": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
+    "@vercel/ncc": "^0.27.0",
+    "arg": "^5.0.0",
+    "chalk": "^4.1.0",
     "eslint": "^7.21.0",
     "eslint-plugin-jest": "^24.2.0",
     "eslint-plugin-prettier": "^3.3.1",
     "execa": "^5.0.0",
     "expect": "^26.6.2",
+    "fs-extra": "^9.0.1",
+    "globby": "^11.0.2",
     "husky": "^5.1.3",
+    "ink": "^3.0.8",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
+    "newsh": "^0.7.4",
     "np": "^7.4.0",
     "prettier": "^2.2.1",
+    "react": "^17.0.1",
     "tempy": "^1.0.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "update-notifier": "^5.1.0"
   },
   "lint-staged": {
     "*.ts": "eslint --cache --fix"

--- a/src/components/Monitor.tsx
+++ b/src/components/Monitor.tsx
@@ -8,7 +8,7 @@ export type Match = {
   matchStartIndex: number;
 };
 
-const confirmText = '- Press "Enter" to confirm';
+const confirmText = '- Press "Enter" to confirm11';
 const searchColor = getSearchColor();
 const replaceColor = getReplaceColor();
 

--- a/src/components/Monitor.tsx
+++ b/src/components/Monitor.tsx
@@ -8,7 +8,7 @@ export type Match = {
   matchStartIndex: number;
 };
 
-const confirmText = '- Press "Enter" to confirm11';
+const confirmText = '- Press "Enter" to confirm';
 const searchColor = getSearchColor();
 const replaceColor = getReplaceColor();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,11 @@
     "@typescript-eslint/types" "4.17.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/ncc@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.27.0.tgz#c0cfeebb0bebb56052719efa4a0ecc090a932c76"
+  integrity sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -1575,7 +1580,7 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-arg@^4.1.0:
+arg@^4.1.0, arg@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
@@ -2189,6 +2194,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
+
 commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -2281,6 +2291,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -4841,6 +4856,17 @@ new-github-release-url@^1.0.0:
   dependencies:
     type-fest "^0.4.1"
 
+newsh@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/newsh/-/newsh-0.7.4.tgz#443fd5fc3618bbf866d56fc508615b40401530c0"
+  integrity sha512-A7jUvXBzEZ0zDSUsnGywLjrJ4WnZMaQ3qtv+H+MeEZQo23hOcO+mRI0NEPlTVEpOqRu5mUWqqRow+LM32JeZ0A==
+  dependencies:
+    arg "^4.1.3"
+    chalk "^3.0.0"
+    command-exists "^1.2.9"
+    execa "^4.0.0"
+    tempy "^0.3.0"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -6260,10 +6286,24 @@ table@^6.0.4:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
 temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
   integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
+tempy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
+  integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
+  dependencies:
+    temp-dir "^1.0.0"
+    type-fest "^0.3.1"
+    unique-string "^1.0.0"
 
 tempy@^1.0.0:
   version "1.0.0"
@@ -6486,6 +6526,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+type-fest@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
+  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
 type-fest@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
@@ -6545,6 +6590,13 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The installation time of relabel with ncc is quite long, it seems to be mostly to dependency resolution.

This PR moves it to use https://github.com/vercel/ncc it should also improve bootstrap time